### PR TITLE
updated to call handlers

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -31,8 +31,6 @@ type TransactionData @entity {
   id: ID!
   # transaction index
   txnIndex: BigInt!
-  # transaction log index
-  txnLogIndex: BigInt!
   # from
   from: Bytes!
   # to

--- a/src/compound-v3-managers.ts
+++ b/src/compound-v3-managers.ts
@@ -24,7 +24,7 @@ export function handleManagerToggledByAllow(call: AllowCall): void {
   let transactionData = createOrLoadTransaction(transactionID);
   transactionData.txnIndex = call.transaction.index;
   transactionData.from = call.transaction.from;
-  transactionData.to = call.transaction.to;
+  transactionData.to = call.to;
   transactionData.input = call.transaction.input;
   transactionData.blockNumber = call.block.number;
   transactionData.timestamp = call.block.timestamp;
@@ -50,7 +50,7 @@ export function handleManagerToggledByAllow(call: AllowCall): void {
   owner.save();
 }
 
-export function handleMnaagerToggledByPermit(call: AllowBySigCall): void {
+export function handleManagerToggledByPermit(call: AllowBySigCall): void {
   let ownerID = call.inputs.owner.toHexString() + "#" + call.to.toHexString();
   let managerID = call.inputs.manager.toHexString() + "#" + ownerID;
   let transactionID =
@@ -61,7 +61,7 @@ export function handleMnaagerToggledByPermit(call: AllowBySigCall): void {
   let transactionData = createOrLoadTransaction(transactionID);
   transactionData.txnIndex = call.transaction.index;
   transactionData.from = call.transaction.from;
-  transactionData.to = call.transaction.to;
+  transactionData.to = call.to;
   transactionData.input = call.transaction.input;
   transactionData.blockNumber = call.block.number;
   transactionData.timestamp = call.block.timestamp;

--- a/src/compound-v3-managers.ts
+++ b/src/compound-v3-managers.ts
@@ -1,40 +1,88 @@
 import {
   cUSDCv3,
-  Approval
-} from "../generated/cUSDCv3/cUSDCv3"
-import { createOrLoadManager, createOrLoadOwner, createOrLoadTransaction, isDSA, ZERO } from "./utils";
+  Approval,
+  AllowCall,
+  AllowBySigCall,
+} from "../generated/cUSDCv3/cUSDCv3";
+import {
+  createOrLoadManager,
+  createOrLoadOwner,
+  createOrLoadTransaction,
+  isDSA,
+  ZERO,
+} from "./utils";
 
-export function handleManagerToggled(event: Approval): void {
-  let ownerID = event.params.owner.toHexString() + "#" + event.address.toHexString();
-  let managerID = event.params.spender.toHexString() + "#" + event.params.owner.toHexString() + "#" + event.address.toHexString();
-  let transactionID = event.transaction.hash.toHexString() +  "#" + event.logIndex.toString();
+export function handleManagerToggledByAllow(call: AllowCall): void {
+  let ownerID =
+    call.transaction.from.toHexString() + "#" + call.to.toHexString();
+  let managerID = call.inputs.manager.toHexString() + "#" + ownerID;
+  let transactionID =
+    call.transaction.hash.toHexString() +
+    "#" +
+    call.transaction.index.toString();
 
   let transactionData = createOrLoadTransaction(transactionID);
-  transactionData.txnIndex = event.transaction.index;
-  transactionData.txnLogIndex = event.transactionLogIndex;
-  transactionData.from = event.transaction.from;
-  transactionData.to = event.transaction.to;
-  transactionData.input = event.transaction.input;
-  transactionData.blockNumber = event.block.number;
-  transactionData.timestamp = event.block.timestamp;
-  transactionData.gasLimit = event.block.gasLimit;
-  transactionData.blockGasUsed = event.block.gasUsed;
-  transactionData.gasPrice = event.transaction.gasPrice;
-  transactionData.value = event.transaction.value;
-  
+  transactionData.txnIndex = call.transaction.index;
+  transactionData.from = call.transaction.from;
+  transactionData.to = call.transaction.to;
+  transactionData.input = call.transaction.input;
+  transactionData.blockNumber = call.block.number;
+  transactionData.timestamp = call.block.timestamp;
+  transactionData.gasLimit = call.block.gasLimit;
+  transactionData.blockGasUsed = call.block.gasUsed;
+  transactionData.gasPrice = call.transaction.gasPrice;
+  transactionData.value = call.transaction.value;
+
   let manager = createOrLoadManager(managerID);
-  manager.address = event.params.spender;
-  manager.isAllowed = event.params.amount == ZERO ? false : true;
+  manager.address = call.inputs.manager;
+  manager.isAllowed = call.inputs.isAllowed_;
   manager.owner = ownerID;
-  manager.market = event.address;
-  manager.isDSA = isDSA(event.params.spender);
+  manager.market = call.to;
+  manager.isDSA = isDSA(call.inputs.manager);
   manager.transactionData = transactionID;
 
   let owner = createOrLoadOwner(ownerID);
-  owner.address = event.params.owner;
-  owner.market = event.address;
+  owner.address = call.transaction.from;
+  owner.market = call.to;
 
   transactionData.save();
   manager.save();
-  owner.save();  
+  owner.save();
+}
+
+export function handleMnaagerToggledByPermit(call: AllowBySigCall): void {
+  let ownerID = call.inputs.owner.toHexString() + "#" + call.to.toHexString();
+  let managerID = call.inputs.manager.toHexString() + "#" + ownerID;
+  let transactionID =
+    call.transaction.hash.toHexString() +
+    "#" +
+    call.transaction.index.toString();
+
+  let transactionData = createOrLoadTransaction(transactionID);
+  transactionData.txnIndex = call.transaction.index;
+  transactionData.from = call.transaction.from;
+  transactionData.to = call.transaction.to;
+  transactionData.input = call.transaction.input;
+  transactionData.blockNumber = call.block.number;
+  transactionData.timestamp = call.block.timestamp;
+  transactionData.gasLimit = call.block.gasLimit;
+  transactionData.blockGasUsed = call.block.gasUsed;
+  transactionData.gasPrice = call.transaction.gasPrice;
+  transactionData.value = call.transaction.value;
+
+  let manager = createOrLoadManager(managerID);
+  manager.address = call.inputs.manager;
+  manager.isAllowed = call.inputs.isAllowed_;
+  manager.owner = ownerID;
+  manager.market = call.to;
+  manager.isDSA = isDSA(call.inputs.manager);
+  manager.transactionData = transactionID;
+
+  let owner = createOrLoadOwner(ownerID);
+  owner.address = call.inputs.owner;
+  owner.market = call.to;
+
+  transactionData.save();
+  manager.save();
+  owner.save();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,6 @@ export function createOrLoadTransaction(id: string): TransactionData {
   if (txn == null) {
     txn = new TransactionData(id);
     txn.txnIndex = ZERO;
-    txn.txnLogIndex = ZERO;
     txn.from = new Address(0);
     txn.to = new Address(0);
     txn.input = new Bytes(0);

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -22,7 +22,9 @@ dataSources:
           file: ./abis/cUSDCv3.json
         - name: InstaList
           file: ./abis/InstaList.json
-      eventHandlers:
-        - event: Approval(indexed address,indexed address,uint256)
-          handler: handleManagerToggled
+      callHandlers:
+        - function: allow(address,bool)
+          handler: handleManagerToggledByAllow
+        - function: allowBySig(address,address,bool,uint256,uint256,uint8,bytes32,bytes32)
+          handler: handleManagerToggledByPermit
       file: ./src/compound-v3-managers.ts


### PR DESCRIPTION
The previous included event fetch of Approval but that also included approval of normal spenders who were not managers, changed the logics to track function calls to `Allow` and `AllowBySig` which are specific for allowing managers.